### PR TITLE
Refactor integration tests using ShapleQTestContext structure 

### DIFF
--- a/broker/pipeline/fetch_pipe.go
+++ b/broker/pipeline/fetch_pipe.go
@@ -71,6 +71,10 @@ func (f *FetchPipe) Ready(inStream <-chan interface{}) (<-chan interface{}, <-ch
 			f.session.SetFlushInterval(req.GetFlushInterval())
 
 			for _, fragmentOffset := range req.FragmentOffsets {
+				if fragmentOffset.StartOffset == 0 {
+					errCh <- pqerror.TopicFragmentOffsetNotSetError{}
+					return
+				}
 				wg.Add(1)
 				go func(fo *shapleq_proto.FetchRequest_OffsetInfo) {
 					defer wg.Done()

--- a/client/admin.go
+++ b/client/admin.go
@@ -123,7 +123,7 @@ func (a *Admin) CreateTopic(topicName string, topicDescription string) error {
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return err
+		return pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return nil
 }
@@ -141,7 +141,7 @@ func (a *Admin) DeleteTopic(topicName string) error {
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return err
+		return pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return nil
 }
@@ -159,7 +159,7 @@ func (a *Admin) DescribeTopic(topicName string) (*shapleqproto.Topic, error) {
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return nil, err
+		return nil, pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return response.Topic, nil
 }
@@ -177,7 +177,7 @@ func (a *Admin) ListTopic() (*shapleqproto.ListTopicResponse, error) {
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return nil, err
+		return nil, pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return response, nil
 }
@@ -197,7 +197,7 @@ func (a *Admin) CreateFragment(topicName string) (*shapleqproto.Fragment, error)
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return nil, err
+		return nil, pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return response.Fragment, nil
 }
@@ -232,7 +232,7 @@ func (a *Admin) DescribeFragment(topicName string, fragmentId uint32) (*shapleqp
 
 	if response.ErrorCode != 0 {
 		a.logger.Error(response.ErrorMessage)
-		return nil, err
+		return nil, pqerror.ZKOperateError{ErrStr: response.ErrorMessage}
 	}
 	return response.Fragment, nil
 }

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -248,7 +248,7 @@ type ShapleQTestContext struct {
 	params            *TestParams
 }
 
-func DefaultShapleQTestContext(testName string, t *testing.T) *ShapleQTestContext {
+func DefaultShapleQTestContext(t *testing.T) *ShapleQTestContext {
 	return &ShapleQTestContext{
 		logLevel:          defaultLogLevel,
 		brokerPorts:       []uint{1101},
@@ -261,7 +261,7 @@ func DefaultShapleQTestContext(testName string, t *testing.T) *ShapleQTestContex
 		consumers:         []*consumerTestContext{},
 		running:           false,
 		t:                 t,
-		params:            predefinedTestParams[testName],
+		params:            predefinedTestParams[t.Name()],
 	}
 }
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -1,0 +1,323 @@
+package integration_test
+
+import (
+	"fmt"
+	"github.com/paust-team/shapleq/broker"
+	"github.com/paust-team/shapleq/broker/config"
+	"github.com/paust-team/shapleq/client"
+	config2 "github.com/paust-team/shapleq/client/config"
+	"github.com/paust-team/shapleq/common"
+	logger "github.com/paust-team/shapleq/log"
+	"github.com/paust-team/shapleq/zookeeper"
+	"sync"
+	"testing"
+	"time"
+)
+
+func Sleep(sec int) {
+	time.Sleep(time.Duration(sec) * time.Second)
+}
+
+var defaultLogLevel = logger.Info
+
+type brokerTestContext struct {
+	config   *config.BrokerConfig
+	instance *broker.Broker
+	wg       sync.WaitGroup
+}
+
+func newBrokerTestContext(port uint, zkAddrs []string, dataDir string, logDir string) *brokerTestContext {
+	cfg := config.NewBrokerConfig()
+	cfg.SetPort(port)
+	cfg.SetLogLevel(defaultLogLevel)
+	cfg.SetZKQuorum(zkAddrs)
+	cfg.SetDataDir(dataDir)
+	cfg.SetLogDir(logDir)
+
+	return &brokerTestContext{
+		config:   cfg,
+		instance: broker.NewBroker(cfg),
+		wg:       sync.WaitGroup{},
+	}
+}
+
+func (b *brokerTestContext) start() {
+	b.wg.Add(1)
+	go func() {
+		defer b.wg.Done()
+		b.instance.Start()
+	}()
+}
+
+func (b *brokerTestContext) stop() {
+	b.instance.Stop()
+	b.wg.Wait()
+	b.instance.Clean()
+}
+
+type producerTestContext struct {
+	config    *config2.ProducerConfig
+	nodeId    string
+	instance  *client.Producer
+	wg        sync.WaitGroup
+	publishCh chan *client.PublishData
+	t         *testing.T
+}
+
+func newProducerTestContext(nodeId string, topic string, t *testing.T) *producerTestContext {
+	producerConfig := config2.NewProducerConfig()
+	producerConfig.SetLogLevel(defaultLogLevel)
+	producerConfig.SetServerAddresses([]string{"127.0.0.1:2181"})
+	producer := client.NewProducer(producerConfig, topic)
+
+	return &producerTestContext{
+		config:    producerConfig,
+		nodeId:    nodeId,
+		instance:  producer,
+		wg:        sync.WaitGroup{},
+		publishCh: make(chan *client.PublishData),
+		t:         t,
+	}
+}
+
+func (p *producerTestContext) start() {
+	if err := p.instance.Connect(); err != nil {
+		p.t.Fatal(err)
+	}
+}
+
+func (p *producerTestContext) stop() {
+	close(p.publishCh)
+	p.instance.Close()
+}
+
+func (p *producerTestContext) asyncPublish(records [][]byte) *producerTestContext {
+	fragmentCh, pubErrCh, err := p.instance.AsyncPublish(p.publishCh)
+	if err != nil {
+		p.t.Fatal(err)
+	}
+
+	p.wg.Add(1)
+	go func(recordLength int) {
+		defer p.wg.Done()
+		published := 0
+		for {
+			select {
+			case err, ok := <-pubErrCh:
+				if !ok {
+					return
+				}
+				if err != nil {
+					p.t.Error(err)
+					return
+				}
+			case _, ok := <-fragmentCh:
+				if !ok {
+					return
+				}
+				//fmt.Printf("publish succeed. fragmentId=%d offset=%d\n", fragment.FragmentId, fragment.LastOffset)
+				published++
+				if published == recordLength {
+					fmt.Printf("publisher(%s) is finished\n", p.nodeId)
+					return
+				}
+			}
+		}
+	}(len(records))
+
+	go func(recordsToPublish [][]byte) {
+		for index, record := range recordsToPublish {
+			p.publishCh <- &client.PublishData{
+				Data:   record,
+				NodeId: p.nodeId,
+				SeqNum: uint64(index),
+			}
+		}
+	}(records)
+
+	return p
+}
+
+func (p *producerTestContext) waitFinished() {
+	p.wg.Wait()
+}
+
+type consumerTestContext struct {
+	config       *config2.ConsumerConfig
+	nodeId       string
+	instance     *client.Consumer
+	wg           sync.WaitGroup
+	onCompleteFn func()
+	t            *testing.T
+}
+
+func newConsumerTestContext(nodeId string, topic string, fragmentOffsets map[uint32]uint64, t *testing.T) *consumerTestContext {
+	consumerConfig := config2.NewConsumerConfig()
+	consumerConfig.SetLogLevel(defaultLogLevel)
+	consumerConfig.SetServerAddresses([]string{"127.0.0.1:2181"})
+	consumer := client.NewConsumer(consumerConfig, topic, fragmentOffsets)
+	return &consumerTestContext{
+		config:   consumerConfig,
+		nodeId:   nodeId,
+		instance: consumer,
+		wg:       sync.WaitGroup{},
+		t:        t,
+	}
+}
+
+func (c *consumerTestContext) start() {
+	if err := c.instance.Connect(); err != nil {
+		c.t.Fatal(err)
+	}
+}
+
+func (c *consumerTestContext) stop() {
+	c.instance.Close()
+}
+
+func (c *consumerTestContext) onSubscribe(maxBatchSize, flushInterval uint32, fn func(*client.SubscribeResult) bool) *consumerTestContext {
+
+	receiveCh, subErrCh, err := c.instance.Subscribe(maxBatchSize, flushInterval)
+	if err != nil {
+		c.t.Fatal(err)
+	}
+	c.wg.Add(1)
+
+	go func() {
+		defer c.wg.Done()
+		for {
+			select {
+			case received, ok := <-receiveCh:
+				if !ok {
+					return
+				}
+				if finished := fn(received); finished {
+					c.onCompleteFn()
+					return
+				}
+
+			case err := <-subErrCh:
+				c.t.Error(err)
+				return
+			}
+		}
+	}()
+
+	return c
+}
+
+func (c *consumerTestContext) onComplete(fn func()) *consumerTestContext {
+	c.onCompleteFn = fn
+	return c
+}
+
+func (c *consumerTestContext) waitFinished() {
+	c.wg.Wait()
+}
+
+type ShapleQTestContext struct {
+	logLevel          logger.LogLevel
+	brokerPorts       []uint
+	zkAddrs           []string
+	zkTimeoutMS       uint
+	zkFlushIntervalMS uint
+	zkClient          *zookeeper.ZKQClient
+	brokers           []*brokerTestContext
+	producers         []*producerTestContext
+	consumers         []*consumerTestContext
+	running           bool
+	adminClient       *client.Admin
+	t                 *testing.T
+}
+
+func DefaultShapleQTestContext(t *testing.T) *ShapleQTestContext {
+	return &ShapleQTestContext{
+		logLevel:          defaultLogLevel,
+		brokerPorts:       []uint{1101},
+		zkAddrs:           []string{"127.0.0.1:2181"},
+		zkTimeoutMS:       3000,
+		zkFlushIntervalMS: 2000,
+		brokers:           []*brokerTestContext{},
+		producers:         []*producerTestContext{},
+		consumers:         []*consumerTestContext{},
+		running:           false,
+		t:                 t,
+	}
+}
+
+func (s *ShapleQTestContext) Start() {
+	s.zkClient = zookeeper.NewZKQClient(s.zkAddrs, s.zkTimeoutMS, s.zkFlushIntervalMS)
+	if err := s.zkClient.Connect(); err != nil {
+		s.t.Fatal(err)
+	}
+	// Start brokers
+	var brokerAddrs []string
+	for index, port := range s.brokerPorts {
+		dataDir := fmt.Sprintf("%s/data-test/broker-%d", common.DefaultHomeDir, index)
+		logDir := fmt.Sprintf("%s/log-test/broker-%d", common.DefaultHomeDir, index)
+		brokerContext := newBrokerTestContext(port, s.zkAddrs, dataDir, logDir)
+		s.brokers = append(s.brokers, brokerContext)
+		brokerContext.start()
+		brokerAddrs = append(brokerAddrs, fmt.Sprintf("127.0.0.1:%d", port))
+	}
+
+	Sleep(1) // wait for starting brokers..
+
+	adminConfig := config2.NewAdminConfig()
+	adminConfig.SetLogLevel(defaultLogLevel)
+	adminConfig.SetServerAddresses(brokerAddrs)
+	s.adminClient = client.NewAdmin(adminConfig)
+	if err := s.adminClient.Connect(); err != nil {
+		s.t.Fatal(err)
+	}
+
+	s.running = true
+}
+
+func (s *ShapleQTestContext) Stop() {
+	if s.running {
+		for _, ctx := range s.producers {
+			ctx.stop()
+		}
+		for _, ctx := range s.consumers {
+			ctx.stop()
+		}
+		for _, ctx := range s.brokers {
+			ctx.stop()
+		}
+		s.zkClient.RemoveAllPath()
+		s.zkClient.Close()
+		s.adminClient.Close()
+	}
+}
+
+func (s *ShapleQTestContext) SetupTopicAndFragments(topic string, fragmentCount int) map[uint32]uint64 {
+	fragmentOffsets := make(map[uint32]uint64)
+
+	if err := s.adminClient.CreateTopic(topic, "test"); err != nil {
+		s.t.Fatal(err)
+	}
+
+	for i := 0; i < fragmentCount; i++ {
+		fragment, err := s.adminClient.CreateFragment(topic)
+		if err != nil {
+			s.t.Fatal(err)
+		}
+		fragmentOffsets[fragment.Id] = 1 // set start offset with 1
+	}
+	return fragmentOffsets
+}
+
+func (s *ShapleQTestContext) AddProducerContext(nodeId string, topic string) *producerTestContext {
+	ctx := newProducerTestContext(nodeId, topic, s.t)
+	ctx.start()
+	s.producers = append(s.producers, ctx)
+	return ctx
+}
+
+func (s *ShapleQTestContext) AddConsumerContext(nodeId string, topic string, fragmentOffsets map[uint32]uint64) *consumerTestContext {
+	ctx := newConsumerTestContext(nodeId, topic, fragmentOffsets, s.t)
+	ctx.start()
+	s.consumers = append(s.consumers, ctx)
+	return ctx
+}

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -461,7 +461,30 @@ var predefinedTestParams = map[string]*TestParams{
 		consumerBatchSize:     32,
 		consumerFlushInterval: 100,
 	},
-
+	"TestMultiFragmentsTotalConsume": {
+		topic:         "topic5",
+		brokerCount:   1,
+		consumerCount: 1,
+		producerCount: 1,
+		fragmentCount: 4,
+		testRecords: []records{
+			getRecordsFromFile("data1.txt"),
+		},
+		consumerBatchSize:     1,
+		consumerFlushInterval: 0,
+	},
+	"TestMultiFragmentsOptionalConsume": {
+		topic:         "topic6",
+		brokerCount:   1,
+		consumerCount: 3,
+		producerCount: 1,
+		fragmentCount: 3,
+		testRecords: []records{
+			getRecordsFromFile("data2.txt"),
+		},
+		consumerBatchSize:     1,
+		consumerFlushInterval: 0,
+	},
 	// RPC tests
 	"TestHeartBeat": {
 		topic:            "rpc-topic1",

--- a/integration_test/rpc_test.go
+++ b/integration_test/rpc_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestHeartBeat(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestHeartBeat", t)
+	testContext := DefaultShapleQTestContext(t)
 	testContext.RunBrokers()
 	defer testContext.Terminate()
 
@@ -25,7 +25,7 @@ func TestHeartBeat(t *testing.T) {
 }
 
 func TestCreateTopicAndFragment(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestCreateTopicAndFragment", t)
+	testContext := DefaultShapleQTestContext(t)
 	testContext.RunBrokers()
 	defer testContext.Terminate()
 
@@ -58,7 +58,7 @@ func TestCreateTopicAndFragment(t *testing.T) {
 }
 
 func TestDeleteTopicAndFragment(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestDeleteTopicAndFragment", t)
+	testContext := DefaultShapleQTestContext(t)
 	testContext.RunBrokers()
 	defer testContext.Terminate()
 
@@ -102,7 +102,7 @@ func TestDeleteTopicAndFragment(t *testing.T) {
 }
 
 func TestDescribeFragment(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestDescribeFragment", t)
+	testContext := DefaultShapleQTestContext(t)
 	testContext.RunBrokers()
 	defer testContext.Terminate()
 

--- a/integration_test/rpc_test.go
+++ b/integration_test/rpc_test.go
@@ -6,12 +6,17 @@ import (
 )
 
 func TestHeartBeat(t *testing.T) {
+	testContext := DefaultShapleQTestContext("TestHeartBeat", t)
+	testContext.RunBrokers()
+	defer testContext.Terminate()
 
-	testContext := DefaultShapleQTestContext(t)
-	testContext.Start()
-	defer testContext.Stop()
+	adminClient := testContext.CreateAdminClient()
+	if err := adminClient.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer adminClient.Close()
 
-	pongMsg, err := testContext.adminClient.Heartbeat("test", 1)
+	pongMsg, err := adminClient.Heartbeat("test", 1)
 	if err != nil {
 		t.Error(pongMsg)
 		return
@@ -20,20 +25,26 @@ func TestHeartBeat(t *testing.T) {
 }
 
 func TestCreateTopicAndFragment(t *testing.T) {
+	testContext := DefaultShapleQTestContext("TestCreateTopicAndFragment", t)
+	testContext.RunBrokers()
+	defer testContext.Terminate()
 
-	testContext := DefaultShapleQTestContext(t)
-	testContext.Start()
-	defer testContext.Stop()
+	adminClient := testContext.CreateAdminClient()
+	if err := adminClient.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer adminClient.Close()
 
-	expectedTopicName := "test-tp1"
-	expectedDescription := "test-description"
-	err := testContext.adminClient.CreateTopic(expectedTopicName, expectedDescription)
+	// test body
+	testParams := testContext.TestParams()
+
+	err := adminClient.CreateTopic(testParams.topic, testParams.topicDescription)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 
-	fragment, err := testContext.adminClient.CreateFragment(expectedTopicName)
+	fragment, err := adminClient.CreateFragment(testParams.topic)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -47,20 +58,26 @@ func TestCreateTopicAndFragment(t *testing.T) {
 }
 
 func TestDeleteTopicAndFragment(t *testing.T) {
+	testContext := DefaultShapleQTestContext("TestDeleteTopicAndFragment", t)
+	testContext.RunBrokers()
+	defer testContext.Terminate()
 
-	testContext := DefaultShapleQTestContext(t)
-	testContext.Start()
-	defer testContext.Stop()
+	adminClient := testContext.CreateAdminClient()
+	if err := adminClient.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer adminClient.Close()
 
-	expectedTopicName := "test-tp2"
-	expectedDescription := "test-description"
-	err := testContext.adminClient.CreateTopic(expectedTopicName, expectedDescription)
+	// test body
+	testParams := testContext.TestParams()
+
+	err := adminClient.CreateTopic(testParams.topic, testParams.topicDescription)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 
-	fragment, err := testContext.adminClient.CreateFragment(expectedTopicName)
+	fragment, err := adminClient.CreateFragment(testParams.topic)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -70,35 +87,41 @@ func TestDeleteTopicAndFragment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = testContext.adminClient.DeleteFragment(expectedTopicName, fragment.Id); err != nil {
+	if err = adminClient.DeleteFragment(testParams.topic, fragment.Id); err != nil {
 		t.Fatal(err)
 	}
 
 	// TODO:: get list of fragments and check whether the fragment is deleted
 
-	if err = testContext.adminClient.DeleteTopic(expectedTopicName); err != nil {
+	if err = adminClient.DeleteTopic(testParams.topic); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := testContext.adminClient.DescribeTopic(expectedTopicName); err == nil {
+	if _, err := adminClient.DescribeTopic(testParams.topic); err == nil {
 		t.Fatal(err)
 	}
 }
 
 func TestDescribeFragment(t *testing.T) {
+	testContext := DefaultShapleQTestContext("TestDescribeFragment", t)
+	testContext.RunBrokers()
+	defer testContext.Terminate()
 
-	testContext := DefaultShapleQTestContext(t)
-	testContext.Start()
-	defer testContext.Stop()
+	adminClient := testContext.CreateAdminClient()
+	if err := adminClient.Connect(); err != nil {
+		t.Fatal(err)
+	}
+	defer adminClient.Close()
 
-	expectedTopicName := "test-tp3"
-	expectedDescription := "test-description"
-	err := testContext.adminClient.CreateTopic(expectedTopicName, expectedDescription)
+	// test body
+	testParams := testContext.TestParams()
+
+	err := adminClient.CreateTopic(testParams.topic, testParams.topicDescription)
 	if err != nil {
 		t.Fatal(err)
 		return
 	}
 
-	fragment, err := testContext.adminClient.CreateFragment(expectedTopicName)
+	fragment, err := adminClient.CreateFragment(testParams.topic)
 	if err != nil {
 		t.Fatal(err)
 		return
@@ -109,7 +132,7 @@ func TestDescribeFragment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	fragment, err = testContext.adminClient.DescribeFragment(expectedTopicName, fragment.Id)
+	fragment, err = adminClient.DescribeFragment(testParams.topic, fragment.Id)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -118,7 +141,7 @@ func TestDescribeFragment(t *testing.T) {
 		t.Error("fragmentId mismatched")
 	}
 
-	topic, err := testContext.adminClient.DescribeTopic(expectedTopicName)
+	topic, err := adminClient.DescribeTopic(testParams.topic)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,5 +151,4 @@ func TestDescribeFragment(t *testing.T) {
 	} else if topic.FragmentIds[0] != expectedFragmentId {
 		t.Error("fragmentId mismatched in topic")
 	}
-
 }

--- a/integration_test/stream_test.go
+++ b/integration_test/stream_test.go
@@ -4,30 +4,13 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"github.com/paust-team/shapleq/broker"
-	"github.com/paust-team/shapleq/broker/config"
 	"github.com/paust-team/shapleq/client"
-	config2 "github.com/paust-team/shapleq/client/config"
 	"github.com/paust-team/shapleq/common"
-	logger "github.com/paust-team/shapleq/log"
-	"github.com/paust-team/shapleq/zookeeper"
 	"log"
 	"os"
 	"sync"
 	"testing"
-	"time"
 )
-
-var testLogLevel = logger.Info
-var brokerPort uint = 1101
-var brokerAddrs = []string{"127.0.0.1:1101"}
-var zkAddrs = []string{"127.0.0.1:2181"}
-var zkTimeoutMS uint = 3000
-var zkFlushIntervalMS uint = 2000
-
-func Sleep(sec int) {
-	time.Sleep(time.Duration(sec) * time.Second)
-}
 
 func getRecordsFromFile(fileName string) [][]byte {
 	f, err := os.Open(fileName)
@@ -54,119 +37,33 @@ func contains(s [][]byte, e []byte) bool {
 	return false
 }
 
-func setupTopicAndFragments(topic string, fragmentCount int, t *testing.T) map[uint32]uint64 {
-	fragmentOffsets := make(map[uint32]uint64)
-	adminConfig := config2.NewAdminConfig()
-	adminConfig.SetLogLevel(testLogLevel)
-	adminConfig.SetServerAddresses(brokerAddrs)
-	admin := client.NewAdmin(adminConfig)
-	defer admin.Close()
-
-	if err := admin.Connect(); err != nil {
-		panic(err)
-	}
-
-	if err := admin.CreateTopic(topic, "test"); err != nil {
-		t.Fatal(err)
-	}
-
-	for i := 0; i < fragmentCount; i++ {
-		fragment, err := admin.CreateFragment(topic)
-		if err != nil {
-			t.Fatal(err)
-		}
-		fragmentOffsets[fragment.Id] = 1 // set start offset with 1
-	}
-	return fragmentOffsets
-}
-
-func TestStreamClient_Connect(t *testing.T) {
-	// zk client to reset
-	zkClient := zookeeper.NewZKQClient(zkAddrs, zkTimeoutMS, zkFlushIntervalMS)
-	if err := zkClient.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-	defer zkClient.Close()
-	defer zkClient.RemoveAllPath()
-
-	// Start broker
-	brokerConfig := config.NewBrokerConfig()
-	brokerConfig.SetPort(brokerPort)
-	brokerConfig.SetLogLevel(testLogLevel)
-	brokerConfig.SetZKQuorum(zkAddrs)
-	brokerInstance := broker.NewBroker(brokerConfig)
-	bwg := sync.WaitGroup{}
-	bwg.Add(1)
-
-	defer brokerInstance.Clean()
-	defer bwg.Wait()
-	defer brokerInstance.Stop()
-
-	go func() {
-		defer bwg.Done()
-		brokerInstance.Start()
-	}()
-
-	Sleep(1)
+func TestConnect(t *testing.T) {
+	testContext := DefaultShapleQTestContext(t)
+	testContext.Start()
+	defer testContext.Stop()
 
 	// setup topic and fragments
-	topic := "test_topic1"
+	nodeId := common.GenerateNodeId()
+	topic := "topic1"
 	fragmentCount := 1
-	fragmentOffsets := setupTopicAndFragments(topic, fragmentCount, t)
+	fragmentOffsets := testContext.SetupTopicAndFragments(topic, fragmentCount)
 
 	// test connect
-	producerConfig := config2.NewProducerConfig()
-	producerConfig.SetLogLevel(testLogLevel)
-	producerConfig.SetServerAddresses(zkAddrs)
-	producer := client.NewProducer(producerConfig, topic)
-	defer producer.Close()
-	if err := producer.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-
-	consumerConfig := config2.NewConsumerConfig()
-	consumerConfig.SetLogLevel(testLogLevel)
-	consumerConfig.SetServerAddresses(zkAddrs)
-	consumer := client.NewConsumer(consumerConfig, topic, fragmentOffsets)
-	defer consumer.Close()
-	if err := consumer.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
+	testContext.AddProducerContext(nodeId, topic)
+	testContext.AddConsumerContext(nodeId, topic, fragmentOffsets)
 }
 
 func TestPubSub(t *testing.T) {
 
-	// zk client to reset
-	zkClient := zookeeper.NewZKQClient(zkAddrs, zkTimeoutMS, zkFlushIntervalMS)
-	if err := zkClient.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-	defer zkClient.Close()
-	defer zkClient.RemoveAllPath()
-
-	// Start broker
-	brokerConfig := config.NewBrokerConfig()
-	brokerConfig.SetLogLevel(testLogLevel)
-	brokerConfig.SetZKQuorum(zkAddrs)
-	brokerInstance := broker.NewBroker(brokerConfig)
-	bwg := sync.WaitGroup{}
-	bwg.Add(1)
-	defer brokerInstance.Clean()
-	defer bwg.Wait()
-	defer brokerInstance.Stop()
-
-	go func() {
-		defer bwg.Done()
-		brokerInstance.Start()
-	}()
-
-	Sleep(1)
+	testContext := DefaultShapleQTestContext(t)
+	testContext.Start()
+	defer testContext.Stop()
 
 	// setup topic and fragments
+	topic := "topic2"
+	fragmentCount := 1
+	fragmentOffsets := testContext.SetupTopicAndFragments(topic, fragmentCount)
+
 	expectedRecords := [][]byte{
 		{'g', 'o', 'o', 'g', 'l', 'e'},
 		{'p', 'a', 'u', 's', 't', 'q'},
@@ -174,448 +71,150 @@ func TestPubSub(t *testing.T) {
 	}
 	nodeId := common.GenerateNodeId()
 	actualRecords := make([][]byte, 0)
-	topic := "topic1"
-	fragmentCount := 1
-	fragmentOffsets := setupTopicAndFragments(topic, fragmentCount, t)
 
-	// Start producer
-	producerConfig := config2.NewProducerConfig()
-	producerConfig.SetLogLevel(testLogLevel)
-	producerConfig.SetServerAddresses(zkAddrs)
-	producer := client.NewProducer(producerConfig, topic)
-	if err := producer.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-	publishCh := make(chan *client.PublishData)
-	defer close(publishCh)
+	// setup clients
+	testContext.AddProducerContext(nodeId, topic).
+		asyncPublish(expectedRecords).
+		waitFinished()
 
-	fragmentCh, pubErrCh, err := producer.AsyncPublish(publishCh)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer producer.Close()
-
-		published := 0
-		for {
-			select {
-			case err := <-pubErrCh:
+	testContext.AddConsumerContext(nodeId, topic, fragmentOffsets).
+		onSubscribe(1, 0, func(received *client.SubscribeResult) bool {
+			actualRecords = append(actualRecords, received.Items[0].Data)
+			fmt.Printf("received fetch result. fragmentId = %d, seq = %d, node id = %s\n", received.Items[0].FragmentId, received.Items[0].SeqNum, received.Items[0].NodeId)
+			if len(actualRecords) == len(expectedRecords) {
+				return true
+			} else {
+				return false
+			}
+		}).
+		onComplete(func() {
+			for _, record := range expectedRecords {
+				if !contains(actualRecords, record) {
+					t.Error("Record is not exists: ", record)
+				}
+			}
+			Sleep(3) // sleep 3 seconds to wait until last offset to be flushed to zk
+			for fragmentId := range fragmentOffsets {
+				fragmentValue, err := testContext.zkClient.GetTopicFragmentData(topic, fragmentId)
 				if err != nil {
-					t.Error(err)
-					return
+					t.Fatal(err)
 				}
-			case fragment := <-fragmentCh:
-				fmt.Printf("publish succeed. fragmentId=%d offset=%d\n", fragment.FragmentId, fragment.LastOffset)
-				published++
-				if published == len(expectedRecords) {
-					return
+
+				if uint64(len(expectedRecords)) != fragmentValue.LastOffset() {
+					t.Errorf("expected last offset (%d) is not matched with (%d)", len(expectedRecords), fragmentValue.LastOffset())
 				}
 			}
-		}
-	}()
-
-	consumerConfig := config2.NewConsumerConfig()
-	consumerConfig.SetLogLevel(testLogLevel)
-	consumerConfig.SetServerAddresses(zkAddrs)
-	consumer := client.NewConsumer(consumerConfig, topic, fragmentOffsets)
-	if err := consumer.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-
-	receiveCh, subErrCh, err := consumer.Subscribe(1, 0)
-	if err != nil {
-		t.Error(err)
-		return
-	}
-
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		defer consumer.Close()
-		for {
-			select {
-			case received := <-receiveCh:
-				actualRecords = append(actualRecords, received.Items[0].Data)
-				fmt.Printf("received fetch result. fragmentId = %d, seq = %d, node id = %s\n",
-					received.Items[0].FragmentId, received.Items[0].SeqNum, received.Items[0].NodeId)
-				if len(actualRecords) == len(expectedRecords) {
-					return
-				}
-			case err := <-subErrCh:
-				t.Error(err)
-				return
-			}
-		}
-	}()
-
-	for index, record := range expectedRecords {
-		publishCh <- &client.PublishData{
-			Data:   record,
-			NodeId: nodeId,
-			SeqNum: uint64(index),
-		}
-	}
-
-	wg.Wait()
-	for _, record := range expectedRecords {
-		if !contains(actualRecords, record) {
-			t.Error("Record is not exists: ", record)
-		}
-	}
-
-	time.Sleep(time.Duration(3) * time.Second) // sleep 3 seconds to wait until last offset to be flushed to zk
-	for fragmentId := range fragmentOffsets {
-		fragmentValue, err := zkClient.GetTopicFragmentData(topic, fragmentId)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if uint64(len(expectedRecords)) != fragmentValue.LastOffset() {
-			t.Errorf("expected last offset (%d) is not matched with (%d)", len(expectedRecords), fragmentValue.LastOffset())
-		}
-	}
+		}).
+		waitFinished()
 }
 
 func TestMultiClient(t *testing.T) {
 
-	//zk client to reset
-	zkClient := zookeeper.NewZKQClient(zkAddrs, zkTimeoutMS, zkFlushIntervalMS)
-	if err := zkClient.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-	defer zkClient.Close()
-	defer zkClient.RemoveAllPath()
-
-	brokerConfig := config.NewBrokerConfig()
-	brokerConfig.SetLogLevel(testLogLevel)
-	brokerConfig.SetZKQuorum(zkAddrs)
-	brokerConfig.SetTimeout(100000)
-	brokerInstance := broker.NewBroker(brokerConfig)
-	bwg := sync.WaitGroup{}
-	bwg.Add(1)
-	defer brokerInstance.Clean()
-	defer bwg.Wait()
-	defer brokerInstance.Stop()
-
-	go func() {
-		defer bwg.Done()
-		brokerInstance.Start()
-	}()
-
-	Sleep(1)
+	testContext := DefaultShapleQTestContext(t)
+	testContext.Start()
+	defer testContext.Stop()
 
 	// setup topic and fragments
 	topic := "topic3"
 	fragmentCount := 1
-	fragmentOffsets := setupTopicAndFragments(topic, fragmentCount, t)
+	fragmentOffsets := testContext.SetupTopicAndFragments(topic, fragmentCount)
 
-	// test multi client
-	runProducer := func(fileName string) [][]byte {
-		nodeId := common.GenerateNodeId()
-		records := getRecordsFromFile(fileName)
-
-		producerConfig := config2.NewProducerConfig()
-		producerConfig.SetLogLevel(testLogLevel)
-		producerConfig.SetServerAddresses(zkAddrs)
-		producerConfig.SetBrokerTimeout(100000)
-		producer := client.NewProducer(producerConfig, topic)
-		if err := producer.Connect(); err != nil {
-			t.Error(err)
-			return nil
-		}
-
-		publishCh := make(chan *client.PublishData)
-
-		partitionCh, pubErrCh, err := producer.AsyncPublish(publishCh)
-		if err != nil {
-			t.Error(err)
-			return nil
-		}
-
-		go func() {
-			defer close(publishCh)
-			defer producer.Close()
-			published := 0
-			for {
-				select {
-				case err := <-pubErrCh:
-					if err != nil {
-						t.Error(err)
-						return
-					}
-				case <-partitionCh:
-					published++
-					if published == len(records) {
-						fmt.Printf("done producer with file %s\n", fileName)
-						return
-					}
-				}
-			}
-		}()
-
-		go func() {
-			for index, record := range records {
-				publishCh <- &client.PublishData{
-					Data:   record,
-					NodeId: nodeId,
-					SeqNum: uint64(index),
-				}
-			}
-		}()
-
-		return records
-	}
-
-	// Start producer
+	// setup clients
 	var totalPublishedRecords [][]byte
-
-	totalPublishedRecords = append(totalPublishedRecords, runProducer("data1.txt")...)
-	totalPublishedRecords = append(totalPublishedRecords, runProducer("data2.txt")...)
-	totalPublishedRecords = append(totalPublishedRecords, runProducer("data3.txt")...)
-
-	// Start consumer
-	type SubscribedRecords [][]byte
-	var totalSubscribedRecords []SubscribedRecords
-	var mu sync.Mutex
 	var wg sync.WaitGroup
 
-	runConsumer := func(name string) {
-		var subscribedRecords SubscribedRecords
+	// setup 3 producers
+	records1 := getRecordsFromFile("data1.txt")
+	records2 := getRecordsFromFile("data2.txt")
+	records3 := getRecordsFromFile("data3.txt")
 
-		consumerConfig := config2.NewConsumerConfig()
-		consumerConfig.SetLogLevel(testLogLevel)
-		consumerConfig.SetServerAddresses(zkAddrs)
-		consumerConfig.SetBrokerTimeout(30000)
-		consumer := client.NewConsumer(consumerConfig, topic, fragmentOffsets)
-		if err := consumer.Connect(); err != nil {
-			t.Error(err)
-			wg.Done()
-			return
-		}
+	totalPublishedRecords = append(totalPublishedRecords, records1...)
+	totalPublishedRecords = append(totalPublishedRecords, records2...)
+	totalPublishedRecords = append(totalPublishedRecords, records3...)
 
-		receiveCh, subErrCh, err := consumer.Subscribe(1, 0)
-		if err != nil {
-			t.Error(err)
-			wg.Done()
-			return
-		}
+	testContext.AddProducerContext(common.GenerateNodeId(), topic).
+		asyncPublish(records1)
+	testContext.AddProducerContext(common.GenerateNodeId(), topic).
+		asyncPublish(records2)
+	testContext.AddProducerContext(common.GenerateNodeId(), topic).
+		asyncPublish(records3)
 
-		go func() {
-			defer wg.Done()
-			defer consumer.Close()
-
-			for {
-				select {
-				case received := <-receiveCh:
-					subscribedRecords = append(subscribedRecords, received.Items[0].Data)
-					if len(subscribedRecords) == len(totalPublishedRecords) {
-						fmt.Printf("done %s\n", name)
-						mu.Lock()
-						totalSubscribedRecords = append(totalSubscribedRecords, subscribedRecords)
-						mu.Unlock()
-						return
-					}
-				case err := <-subErrCh:
-					t.Error(err)
-					return
-				}
-			}
-		}()
-	}
-
-	consumerCount := 1
-	wg.Add(consumerCount)
+	// setup n consumers
+	var consumerCount = 5
+	type SubscribedRecords [][]byte
+	totalSubscribedRecords := make([]SubscribedRecords, consumerCount)
 
 	for i := 0; i < consumerCount; i++ {
-		runConsumer(fmt.Sprintf("consumer%d", i))
+		wg.Add(1)
+		func(index int) {
+			nodeId := fmt.Sprintf("consumer%024d", index)
+			testContext.AddConsumerContext(nodeId, topic, fragmentOffsets).
+				onSubscribe(1, 0, func(received *client.SubscribeResult) bool {
+					totalSubscribedRecords[index] = append(totalSubscribedRecords[index], received.Items[0].Data)
+					if len(totalSubscribedRecords[index]) == len(totalPublishedRecords) {
+						fmt.Printf("consumer(%s) is finished\n", nodeId)
+						return true
+					} else {
+						return false
+					}
+				}).
+				onComplete(func() {
+					wg.Done()
+					for _, record := range totalSubscribedRecords[index] {
+						if !contains(totalPublishedRecords, record) {
+							t.Errorf("Record(%s) is not exists: consumer(%s) ", record, nodeId)
+						}
+					}
+				})
+		}(i)
 	}
-
 	wg.Wait()
-
-	for _, subscribedRecords := range totalSubscribedRecords {
-		if len(totalPublishedRecords) != len(subscribedRecords) {
-			t.Error("Length Mismatch - Expected records: ", len(totalPublishedRecords), ", Received records: ", len(subscribedRecords))
-		}
-
-		for _, record := range subscribedRecords {
-			if !contains(totalPublishedRecords, record) {
-				t.Error("Record is not exists: ", record)
-			}
-		}
-	}
 }
 
-func TestBatchClient(t *testing.T) {
-	//zk client to reset
-	zkClient := zookeeper.NewZKQClient(zkAddrs, zkTimeoutMS, zkFlushIntervalMS)
-	if err := zkClient.Connect(); err != nil {
-		t.Error(err)
-		return
-	}
-	defer zkClient.Close()
-	defer zkClient.RemoveAllPath()
-
-	brokerConfig := config.NewBrokerConfig()
-	brokerConfig.SetLogLevel(testLogLevel)
-	brokerConfig.SetZKQuorum(zkAddrs)
-	brokerConfig.SetTimeout(100000)
-	brokerInstance := broker.NewBroker(brokerConfig)
-	bwg := sync.WaitGroup{}
-	bwg.Add(1)
-	defer brokerInstance.Clean()
-	defer bwg.Wait()
-	defer brokerInstance.Stop()
-
-	go func() {
-		defer bwg.Done()
-		brokerInstance.Start()
-	}()
-
-	Sleep(1)
+func TestBatchedFetch(t *testing.T) {
+	testContext := DefaultShapleQTestContext(t)
+	testContext.Start()
+	defer testContext.Stop()
 
 	// setup topic and fragments
-	var maxBatchSize uint32 = 32
-	var flushInterval uint32 = 200
 	topic := "topic4"
 	fragmentCount := 1
-	fragmentOffsets := setupTopicAndFragments(topic, fragmentCount, t)
-
-	// test batch client
-	runProducer := func(fileName string) [][]byte {
-		nodeId := common.GenerateNodeId()
-		records := getRecordsFromFile(fileName)
-
-		producerConfig := config2.NewProducerConfig()
-		producerConfig.SetLogLevel(testLogLevel)
-		producerConfig.SetServerAddresses(zkAddrs)
-		producerConfig.SetBrokerTimeout(100000)
-		producer := client.NewProducer(producerConfig, topic)
-		if err := producer.Connect(); err != nil {
-			t.Error(err)
-			return nil
-		}
-
-		publishCh := make(chan *client.PublishData)
-
-		partitionCh, pubErrCh, err := producer.AsyncPublish(publishCh)
-		if err != nil {
-			t.Error(err)
-			return nil
-		}
-
-		go func() {
-			defer close(publishCh)
-			defer producer.Close()
-			published := 0
-			for {
-				select {
-				case err := <-pubErrCh:
-					if err != nil {
-						t.Error(err)
-						return
-					}
-				case <-partitionCh:
-					published++
-					if published == len(records) {
-						fmt.Printf("done producer with file %s\n", fileName)
-						return
-					}
-				}
-			}
-		}()
-
-		go func() {
-			for index, record := range records {
-				publishCh <- &client.PublishData{
-					Data:   record,
-					NodeId: nodeId,
-					SeqNum: uint64(index),
-				}
-			}
-		}()
-
-		return records
-	}
-
-	// Start producer
+	fragmentOffsets := testContext.SetupTopicAndFragments(topic, fragmentCount)
+	nodeId := common.GenerateNodeId()
+	// setup clients
 	var totalPublishedRecords [][]byte
-	totalPublishedRecords = append(totalPublishedRecords, runProducer("data1.txt")...)
 
-	// Start consumer
-	type SubscribedRecords [][]byte
-	var totalSubscribedRecords []SubscribedRecords
-	var mu sync.Mutex
-	var wg sync.WaitGroup
+	// setup producer
+	records1 := getRecordsFromFile("data1.txt")
+	totalPublishedRecords = append(totalPublishedRecords, records1...)
 
-	runConsumer := func(name string) {
-		var subscribedRecords SubscribedRecords
+	testContext.AddProducerContext(nodeId, topic).
+		asyncPublish(records1)
 
-		consumerConfig := config2.NewConsumerConfig()
-		consumerConfig.SetLogLevel(testLogLevel)
-		consumerConfig.SetServerAddresses(zkAddrs)
-		consumerConfig.SetBrokerTimeout(30000)
-		consumer := client.NewConsumer(consumerConfig, topic, fragmentOffsets)
-		if err := consumer.Connect(); err != nil {
-			t.Error(err)
-			wg.Done()
-			return
-		}
+	// setup consumer with batch size and flush interval
+	var maxBatchSize uint32 = 32
+	var flushInterval uint32 = 200
+	actualRecords := make([][]byte, 0)
 
-		receiveCh, subErrCh, err := consumer.Subscribe(maxBatchSize, flushInterval)
-		if err != nil {
-			t.Error(err)
-			wg.Done()
-			return
-		}
+	testContext.AddConsumerContext(nodeId, topic, fragmentOffsets).
+		onSubscribe(maxBatchSize, flushInterval, func(received *client.SubscribeResult) bool {
+			for _, data := range received.Items {
+				actualRecords = append(actualRecords, data.Data)
+			}
 
-		go func() {
-			defer wg.Done()
-			defer consumer.Close()
-
-			for {
-				select {
-				case received := <-receiveCh:
-					for _, data := range received.Items {
-						subscribedRecords = append(subscribedRecords, data.Data)
-					}
-
-					if len(subscribedRecords) == len(totalPublishedRecords) {
-						fmt.Printf("done %s\n", name)
-						mu.Lock()
-						totalSubscribedRecords = append(totalSubscribedRecords, subscribedRecords)
-						mu.Unlock()
-						return
-					}
-				case err := <-subErrCh:
-					t.Error(err)
-					return
+			if len(actualRecords) == len(totalPublishedRecords) {
+				fmt.Printf("consumer(%s) is finished\n", nodeId)
+				return true
+			} else {
+				return false
+			}
+		}).
+		onComplete(func() {
+			for _, record := range actualRecords {
+				if !contains(totalPublishedRecords, record) {
+					t.Errorf("Record(%s) is not exists: consumer(%s) ", record, nodeId)
 				}
 			}
-		}()
-	}
-
-	wg.Add(2)
-	runConsumer(fmt.Sprintf("consumer%d", 1))
-	runConsumer(fmt.Sprintf("consumer%d", 2))
-	wg.Wait()
-
-	for _, subscribedRecords := range totalSubscribedRecords {
-		if len(totalPublishedRecords) != len(subscribedRecords) {
-			t.Error("Length Mismatch - Expected records: ", len(totalPublishedRecords), ", Received records: ", len(subscribedRecords))
-		}
-
-		for _, record := range subscribedRecords {
-			if !contains(totalPublishedRecords, record) {
-				t.Error("Record is not exists: ", record)
-			}
-		}
-	}
+		}).
+		waitFinished()
 }

--- a/integration_test/stream_test.go
+++ b/integration_test/stream_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestConnect(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestConnect", t).
+	testContext := DefaultShapleQTestContext(t).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()
@@ -24,7 +24,7 @@ func TestConnect(t *testing.T) {
 
 func TestPubSub(t *testing.T) {
 
-	testContext := DefaultShapleQTestContext("TestPubSub", t).
+	testContext := DefaultShapleQTestContext(t).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()
@@ -79,7 +79,7 @@ func TestPubSub(t *testing.T) {
 
 func TestMultiClient(t *testing.T) {
 
-	testContext := DefaultShapleQTestContext("TestMultiClient", t).
+	testContext := DefaultShapleQTestContext(t).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()
@@ -134,7 +134,7 @@ func TestMultiClient(t *testing.T) {
 }
 
 func TestBatchedFetch(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestBatchedFetch", t).
+	testContext := DefaultShapleQTestContext(t).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()
@@ -182,7 +182,8 @@ func TestBatchedFetch(t *testing.T) {
 }
 
 func TestMultiFragmentsTotalConsume(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestMultiFragmentsTotalConsume", t).
+
+	testContext := DefaultShapleQTestContext(t).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()
@@ -224,7 +225,7 @@ func TestMultiFragmentsTotalConsume(t *testing.T) {
 }
 
 func TestMultiFragmentsOptionalConsume(t *testing.T) {
-	testContext := DefaultShapleQTestContext("TestMultiFragmentsOptionalConsume", t)
+	testContext := DefaultShapleQTestContext(t)
 	testContext.
 		WithBrokerTimeout(1500).
 		RunBrokers().

--- a/pqerror/codes.go
+++ b/pqerror/codes.go
@@ -7,14 +7,15 @@ const (
 	Success PQCode = 0x0000
 
 	// 01 - msg or field error
-	ErrInvalidMsgType     = 0x0100
-	ErrInvalidStartOffset = 0x0101
-	ErrMarshalAnyFailed   = 0x0102
-	ErrUnmarshalAnyFailed = 0x0103
-	ErrMarshalFailed      = 0x0104
-	ErrUnmarshalFailed    = 0x0105
-	ErrTopicNotSet        = 0x0106
-	ErrInvalidNodeId      = 0x0107
+	ErrInvalidMsgType            = 0x0100
+	ErrInvalidStartOffset        = 0x0101
+	ErrMarshalAnyFailed          = 0x0102
+	ErrUnmarshalAnyFailed        = 0x0103
+	ErrMarshalFailed             = 0x0104
+	ErrUnmarshalFailed           = 0x0105
+	ErrTopicNotSet               = 0x0106
+	ErrInvalidNodeId             = 0x0107
+	ErrTopicFragmentOffsetNotSet = 0x0108
 
 	// 02 - zookeeper related error
 	ErrZKConnection          = 0x0200

--- a/pqerror/errors.go
+++ b/pqerror/errors.go
@@ -424,7 +424,7 @@ func (e InvalidMsgTypeToUnpackError) IsSessionCloseable() {}
 type TopicNotSetError struct{}
 
 func (e TopicNotSetError) Error() string {
-	return "topic isn't set"
+	return "topic does not set"
 }
 
 func (e TopicNotSetError) Code() PQCode {
@@ -433,6 +433,19 @@ func (e TopicNotSetError) Code() PQCode {
 
 func (e TopicNotSetError) IsSessionCloseable() {}
 func (e TopicNotSetError) IsClientVisible()    {}
+
+type TopicFragmentOffsetNotSetError struct{}
+
+func (e TopicFragmentOffsetNotSetError) Error() string {
+	return "offset for topic-fragment should be larger than 0"
+}
+
+func (e TopicFragmentOffsetNotSetError) Code() PQCode {
+	return ErrTopicFragmentOffsetNotSet
+}
+
+func (e TopicFragmentOffsetNotSetError) IsSessionCloseable() {}
+func (e TopicFragmentOffsetNotSetError) IsClientVisible()    {}
 
 type InvalidNodeIdError struct {
 	Id string


### PR DESCRIPTION
close #150 

### Test dependency
This PR is separated from #148 to make that PR smaller, which means some tests are bound by the implementations from that PR. I had performed all tests on the #148's branch and checked all test is passed. I suggest the reviewers to focus on the structure of test-context(`integration_test.go`) and much much clearer test body(`stream_test.go`, `rpc_test.go`) itself. 