### PR TITLE
Add TopicName to FetchedData

### DIFF
--- a/client/consumer.go
+++ b/client/consumer.go
@@ -154,6 +154,7 @@ func (c *Consumer) Close() {
 
 type FetchedData struct {
 	Data           []byte
+	TopicName      string
 	FragmentId     uint32
 	Offset, SeqNum uint64
 	NodeId         string
@@ -171,6 +172,7 @@ func (c *Consumer) handleMessage(msg *message.QMessage) (*SubscribeResult, error
 			fetchRes.Data, fetchRes.LastOffset, fetchRes.Offset, fetchRes.SeqNum, fetchRes.NodeId))
 		fetched := &FetchedData{
 			Data:       fetchRes.Data,
+			TopicName:  fetchRes.TopicName,
 			FragmentId: fetchRes.FragmentId,
 			Offset:     fetchRes.Offset,
 			SeqNum:     fetchRes.SeqNum,
@@ -187,6 +189,7 @@ func (c *Consumer) handleMessage(msg *message.QMessage) (*SubscribeResult, error
 		for _, item := range fetchRes.Items {
 			fetched = append(fetched, &FetchedData{
 				Data:       item.Data,
+				TopicName:  item.TopicName,
 				FragmentId: item.FragmentId,
 				Offset:     item.Offset,
 				SeqNum:     item.SeqNum,


### PR DESCRIPTION
I added topic_name to FetchResponse message at [this commit](https://github.com/paust-team/shapleq/commit/818e7f5e933074bfc4b9de7151a87df235dbecfe#diff-ecf0878b123623e280a40f3e3d75af4267f11cfe7138753e671654c0ba05f228) but I forgot to add topic_name to FetchedData struct