### PR TITLE
Refactor busy-waiting loops

### DIFF
--- a/broker/pipeline/collect_pipe.go
+++ b/broker/pipeline/collect_pipe.go
@@ -5,7 +5,6 @@ import (
 	"github.com/paust-team/shapleq/message"
 	"github.com/paust-team/shapleq/pqerror"
 	shapleqproto "github.com/paust-team/shapleq/proto/pb"
-	"runtime"
 	"sync"
 	"time"
 )
@@ -112,7 +111,6 @@ func (c *CollectPipe) watchQueue(topicName string, inStreamClosed chan struct{},
 				timer.Reset(blockingInterval)
 			}
 		}
-		runtime.Gosched()
 	}
 }
 

--- a/broker/pipeline/connect_pipe.go
+++ b/broker/pipeline/connect_pipe.go
@@ -6,7 +6,6 @@ import (
 	"github.com/paust-team/shapleq/pqerror"
 	shapleq_proto "github.com/paust-team/shapleq/proto/pb"
 	"github.com/paust-team/shapleq/zookeeper"
-	"runtime"
 )
 
 type ConnectPipe struct {
@@ -101,7 +100,6 @@ func (c *ConnectPipe) Ready(inStream <-chan interface{}) (<-chan interface{}, <-
 			}
 
 			outStream <- out
-			runtime.Gosched()
 		}
 	}()
 

--- a/broker/pipeline/dispatch_pipe.go
+++ b/broker/pipeline/dispatch_pipe.go
@@ -4,7 +4,6 @@ import (
 	"github.com/paust-team/shapleq/message"
 	"github.com/paust-team/shapleq/pqerror"
 	shapleqproto "github.com/paust-team/shapleq/proto/pb"
-	"runtime"
 )
 
 func IsConnectRequest(data interface{}) (interface{}, bool) {
@@ -101,7 +100,6 @@ func (d *DispatchPipe) Ready(inStream <-chan interface{}) ([]<-chan interface{},
 				errCh <- pqerror.InvalidMsgTypeToUnpackError{}
 				return
 			}
-			runtime.Gosched()
 		}
 	}()
 

--- a/broker/pipeline/fetch_pipe.go
+++ b/broker/pipeline/fetch_pipe.go
@@ -9,7 +9,6 @@ import (
 	"github.com/paust-team/shapleq/pqerror"
 	shapleq_proto "github.com/paust-team/shapleq/proto/pb"
 	"github.com/paust-team/shapleq/zookeeper"
-	"runtime"
 	"sync"
 	"time"
 	"unsafe"
@@ -83,8 +82,6 @@ func (f *FetchPipe) Ready(inStream <-chan interface{}) (<-chan interface{}, <-ch
 					}(topic.TopicName, offset)
 				}
 			}
-
-			runtime.Gosched()
 		}
 	}()
 
@@ -146,7 +143,5 @@ func (f *FetchPipe) iterateRecords(topicName string, fragmentId uint32, startOff
 			}
 		}
 		timer.Reset(iterateInterval)
-
-		runtime.Gosched()
 	}
 }

--- a/broker/pipeline/pipeline.go
+++ b/broker/pipeline/pipeline.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"context"
 	"github.com/paust-team/shapleq/pqerror"
-	"runtime"
 )
 
 type Pipeline struct {
@@ -132,12 +131,10 @@ func (p *Pipeline) Take(outletIndex int, num int) <-chan interface{} {
 		if num == 0 {
 			for out := range p.outlets[outletIndex] {
 				takeStream <- out
-				runtime.Gosched()
 			}
 		} else {
 			for i := 0; i < num; i++ {
 				takeStream <- <-p.outlets[outletIndex]
-				runtime.Gosched()
 			}
 		}
 	}()
@@ -149,17 +146,6 @@ func (p *Pipeline) Flow(inletIndex int, data ...interface{}) {
 	go func() {
 		for _, datum := range data {
 			p.Inlets[inletIndex] <- datum
-			runtime.Gosched()
 		}
 	}()
-}
-
-func WaitForPipeline(ErrChannels ...<-chan error) error {
-	errCh := pqerror.MergeErrors(ErrChannels...)
-	for err := range errCh {
-		if err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/broker/pipeline/put_pipe.go
+++ b/broker/pipeline/put_pipe.go
@@ -7,7 +7,6 @@ import (
 	"github.com/paust-team/shapleq/pqerror"
 	shapleq_proto "github.com/paust-team/shapleq/proto/pb"
 	"github.com/paust-team/shapleq/zookeeper"
-	"runtime"
 	"sync"
 )
 
@@ -84,7 +83,6 @@ func (p *PutPipe) Ready(inStream <-chan interface{}) (<-chan interface{}, <-chan
 			}
 
 			outStream <- out
-			runtime.Gosched()
 		}
 	}()
 

--- a/broker/pipeline/zip_pipe.go
+++ b/broker/pipeline/zip_pipe.go
@@ -1,7 +1,6 @@
 package pipeline
 
 import (
-	"runtime"
 	"sync"
 )
 
@@ -21,7 +20,6 @@ func (z *ZipPipe) Ready(inStreams []<-chan interface{}) (<-chan interface{}, <-c
 		defer waitGroup.Done()
 		for in := range inStream {
 			outStream <- in
-			runtime.Gosched()
 		}
 	}
 

--- a/broker/service/stream_service.go
+++ b/broker/service/stream_service.go
@@ -42,10 +42,7 @@ func (s *StreamService) HandleEventStreams(brokerCtx context.Context,
 					wg.Add(1)
 					go s.handleEventStream(eventStream, sessionErrCh, &wg)
 				}
-			default:
-
 			}
-			runtime.Gosched()
 		}
 	}()
 
@@ -60,9 +57,7 @@ func (s *StreamService) handleEventStream(eventStream internals.EventStream, ses
 	cancelSession := eventStream.CancelSession
 
 	err, pl := s.newPipelineBase(session, convertToInterfaceChan(msgCh))
-
-	writeErrCh, err := session.ContinuousWrite(sessionCtx,
-		convertToQMessageChan(pl.Take(0, 0)))
+	writeErrCh, err := session.ContinuousWrite(sessionCtx, convertToQMessageChan(pl.Take(0, 0)))
 	if err != nil {
 		return
 	}
@@ -74,6 +69,7 @@ func (s *StreamService) handleEventStream(eventStream internals.EventStream, ses
 		select {
 		case <-sessionCtx.Done():
 			return
+
 		case err, ok := <-errCh:
 			if ok {
 				pqErr, ok := err.(pqerror.PQError)
@@ -89,9 +85,7 @@ func (s *StreamService) handleEventStream(eventStream internals.EventStream, ses
 						CancelSession: cancelSession}
 				}
 			}
-		default:
 		}
-		runtime.Gosched()
 	}
 }
 

--- a/broker/service/transaction_service.go
+++ b/broker/service/transaction_service.go
@@ -60,15 +60,12 @@ func (s *TransactionService) HandleEventStreams(brokerCtx context.Context, event
 								if err := s.handleMsg(msg, eventStream.Session); err != nil {
 									errCh <- err
 								}
-							default:
 							}
 							runtime.Gosched()
 						}
 					}()
 				}
-			default:
 			}
-			runtime.Gosched()
 		}
 	}()
 

--- a/integration_test/integration_test.go
+++ b/integration_test/integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/paust-team/shapleq/zookeeper"
 	"log"
 	"os"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -127,6 +128,7 @@ func (p *producerTestContext) asyncPublish(records [][]byte) *producerTestContex
 					return
 				}
 			}
+			runtime.Gosched()
 		}
 	}(len(records))
 
@@ -215,6 +217,7 @@ func (c *consumerTestContext) onSubscribe(maxBatchSize, flushInterval uint32, fn
 				}
 				return
 			}
+			runtime.Gosched()
 		}
 	}()
 

--- a/integration_test/stream_test.go
+++ b/integration_test/stream_test.go
@@ -86,6 +86,7 @@ func TestPubSub(t *testing.T) {
 func TestMultiClient(t *testing.T) {
 
 	testContext := DefaultShapleQTestContext(t).
+		WithBrokerTimeout(0).
 		RunBrokers().
 		SetupTopics()
 	defer testContext.Terminate()

--- a/log/logger.go
+++ b/log/logger.go
@@ -121,7 +121,7 @@ func (l *QLogger) Debug(v ...interface{}) {
 }
 
 func (l *QLogger) Debugf(format string, v ...interface{}) {
-	l.log(Debug, fmt.Sprintf(format, v))
+	l.log(Debug, fmt.Sprintf(format, v...))
 }
 
 func (l *QLogger) Info(v ...interface{}) {
@@ -129,7 +129,7 @@ func (l *QLogger) Info(v ...interface{}) {
 }
 
 func (l *QLogger) Infof(format string, v ...interface{}) {
-	l.log(Info, fmt.Sprintf(format, v))
+	l.log(Info, fmt.Sprintf(format, v...))
 }
 
 func (l *QLogger) Warning(v ...interface{}) {
@@ -137,7 +137,7 @@ func (l *QLogger) Warning(v ...interface{}) {
 }
 
 func (l *QLogger) Warningf(format string, v ...interface{}) {
-	l.log(Warning, fmt.Sprintf(format, v))
+	l.log(Warning, fmt.Sprintf(format, v...))
 }
 
 func (l *QLogger) Error(v ...interface{}) {
@@ -145,7 +145,7 @@ func (l *QLogger) Error(v ...interface{}) {
 }
 
 func (l *QLogger) Errorf(format string, v ...interface{}) {
-	l.log(Error, fmt.Sprintf(format, v))
+	l.log(Error, fmt.Sprintf(format, v...))
 	l.Print()
 }
 


### PR DESCRIPTION
### related to #162 
* I refactored the some code that causing the deadlock of channels (8bd61f4b60bece93eaa235191b02f0eb0677b71f)

### Additional changes
* Reuse the timer(time.After) by resetting it (reference - [Not Pay Attention to Too Many Resources Are Consumed by Calls to the time.After Function](https://go101.org/article/concurrent-common-mistakes.html) )
* Fix bug of printing formatted log in the logger package