### PR TITLE
Fix a bug on DeleteRange logic

### DIFF
--- a/broker/internals/scheduler.go
+++ b/broker/internals/scheduler.go
@@ -38,7 +38,9 @@ func (r *RetentionScheduler) Run(ctx context.Context) {
 				return
 			case <-timer.C:
 				deletedCount, err := r.db.DeleteExpiredRecords()
-				r.logger.Infof("%d records are deleted.", deletedCount)
+				if deletedCount > 0 {
+					r.logger.Infof("%d records are deleted.", deletedCount)
+				}
 
 				if err != nil {
 					r.logger.Error(err)

--- a/broker/storage/qrocksdb.go
+++ b/broker/storage/qrocksdb.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"bytes"
 	"errors"
 	"github.com/linxGnu/grocksdb"
 	"path/filepath"
@@ -123,7 +124,13 @@ func (db *QRocksDB) DeleteExpiredRecords() (deletedCount int, deletionErr error)
 			deletedCount++
 		}
 	}
-	deletionErr = db.db.DeleteRangeCF(db.wo, db.ColumnFamilyHandles()[RecordExpCF], startRetentionKey, endRetentionKey)
+
+	if bytes.Compare(startRetentionKey, endRetentionKey) == 0 {
+		deletionErr = db.db.DeleteCF(db.wo, db.ColumnFamilyHandles()[RecordExpCF], startRetentionKey)
+	} else {
+		deletionErr = db.db.DeleteRangeCF(db.wo, db.ColumnFamilyHandles()[RecordExpCF], startRetentionKey, endRetentionKey)
+		deletionErr = db.db.DeleteCF(db.wo, db.ColumnFamilyHandles()[RecordExpCF], endRetentionKey)
+	}
 	return
 }
 


### PR DESCRIPTION
Fix record deletion bug of #189.

On grocksdb comment, it said that
> DeleteRangeCF deletes keys that are between [startKey, endKey)