### PR TITLE
Edit pubsub interface to pass context from outside

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -103,12 +103,12 @@ func (s *Instance) Stop() {
 	logger.Info("agent finished")
 }
 
-func (s *Instance) StartPublish(topicName string, sendChan chan pubsub.TopicData) error {
+func (s *Instance) StartPublish(ctx context.Context, topicName string, sendChan chan pubsub.TopicData) error {
 	if !s.running {
 		return errors.New("not running state")
 	}
 	retentionPeriod := uint64(s.config.RetentionPeriod() * 60 * 60 * 24)
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	if err := s.publisher.SetupGrpcServer(ctx, s.config.BindAddress(), s.config.Port()); err != nil {
 		cancel()
@@ -145,11 +145,11 @@ func (s *Instance) StartPublish(topicName string, sendChan chan pubsub.TopicData
 	return nil
 }
 
-func (s *Instance) StartSubscribe(topicName string, batchSize, flushInterval uint32) (chan []pubsub.SubscriptionResult, error) {
+func (s *Instance) StartSubscribe(ctx context.Context, topicName string, batchSize, flushInterval uint32) (chan []pubsub.SubscriptionResult, error) {
 	if !s.running {
 		return nil, errors.New("not running state")
 	}
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 
 	recvCh, errCh, err := s.subscriber.PrepareSubscription(ctx, topicName, batchSize, flushInterval)
 	if err != nil {

--- a/agent/agent_test.go
+++ b/agent/agent_test.go
@@ -1,6 +1,7 @@
 package agent_test
 
 import (
+	"context"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/paust-team/shapleq/agent"
@@ -24,7 +25,7 @@ var _ = Describe("Agent", func() {
 			var subscriber *agent.Instance
 
 			BeforeAll(func() {
-				coordClient = helper.BuildCoordClient(config.NewAgentConfig())
+				coordClient = helper.BuildCoordClient([]string{}, 2118) // in-memory coord client
 				topicClient = topic.NewCoordClientTopicWrapper(coordClient)
 			})
 			AfterAll(func() {
@@ -70,7 +71,7 @@ var _ = Describe("Agent", func() {
 
 			When("nothing published to the topic", func() {
 				It("cannot start to subscribe", func() {
-					_, err := subscriber.StartSubscribe(tp.GetString("topic"), tp.GetUint32("batchSize"), tp.GetUint32("flushInterval"))
+					_, err := subscriber.StartSubscribe(context.Background(), tp.GetString("topic"), tp.GetUint32("batchSize"), tp.GetUint32("flushInterval"))
 					Expect(err).To(BeAssignableToTypeOf(qerror.TargetNotExistError{}))
 				})
 			})
@@ -104,7 +105,7 @@ var _ = Describe("Agent", func() {
 
 					// publish
 					sendCh = make(chan pubsub.TopicData)
-					err = publisher.StartPublish(tp.GetString("topic"), sendCh)
+					err = publisher.StartPublish(context.Background(), tp.GetString("topic"), sendCh)
 					Expect(err).NotTo(HaveOccurred())
 
 					for i, record := range tp.GetBytesList("records") {
@@ -119,7 +120,7 @@ var _ = Describe("Agent", func() {
 				})
 
 				It("can subscribe all published records", func() {
-					recvCh, err := subscriber.StartSubscribe(tp.GetString("topic"), tp.GetUint32("batchSize"), tp.GetUint32("flushInterval"))
+					recvCh, err := subscriber.StartSubscribe(context.Background(), tp.GetString("topic"), tp.GetUint32("batchSize"), tp.GetUint32("flushInterval"))
 					Expect(err).NotTo(HaveOccurred())
 
 					idx := 0

--- a/coordinating/zk/coordclient.go
+++ b/coordinating/zk/coordclient.go
@@ -17,7 +17,7 @@ func NewZKCoordClient(quorum []string, timeout uint) *CoordClient {
 	return &CoordClient{quorum: quorum, timeout: timeout}
 }
 
-func (c CoordClient) Connect() error {
+func (c *CoordClient) Connect() error {
 	conn, _, err := zk.Connect(c.quorum, time.Millisecond*time.Duration(c.timeout))
 
 	if err != nil {


### PR DESCRIPTION
Both `StartPublish` and `StartSubscribe` interface use `context.Context` that is only Background. It has a problem controlling the `channel`.

Then, I edit the interface to pass context from outside for controlling channel and pubsub.

## Changes
- Edit pubsub interface
- Fix some bugs for coordinator