### PR TITLE
Fix some bugs on deleting expired records

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,11 @@ $(CLIENT_BIN):
 .PHONY: build-broker
 build-broker: $(BROKER_BIN)
 
+.PHONY: build-agent
+build-agent: $(CLIENT_BIN)
+
 .PHONY: all build rebuild install test clean-rocksdb clean-proto
-build: build-broker install-config
+build: build-broker build-agent install-config
 all: build
 
 install-config:

--- a/agent/storage/qrocksdb.go
+++ b/agent/storage/qrocksdb.go
@@ -39,6 +39,8 @@ type QRocksDB struct {
 	db                  *grocksdb.DB
 	ro                  *grocksdb.ReadOptions
 	wo                  *grocksdb.WriteOptions
+	dwo                 *grocksdb.WriteOptions
+	fo                  *grocksdb.FlushOptions
 	columnFamilyHandles grocksdb.ColumnFamilyHandles
 }
 
@@ -65,7 +67,12 @@ func NewQRocksDB(name, dir string) (*QRocksDB, error) {
 	ro := grocksdb.NewDefaultReadOptions()
 	ro.SetTailing(true)
 	wo := grocksdb.NewDefaultWriteOptions()
-	return &QRocksDB{dbPath: dbPath, db: db, ro: ro, wo: wo, columnFamilyHandles: columnFamilyHandles}, nil
+	dwo := grocksdb.NewDefaultWriteOptions()
+	dwo.SetLowPri(true)
+	fo := grocksdb.NewDefaultFlushOptions()
+	fo.SetWait(false)
+
+	return &QRocksDB{dbPath: dbPath, db: db, ro: ro, wo: wo, dwo: dwo, fo: fo, columnFamilyHandles: columnFamilyHandles}, nil
 }
 
 func (db *QRocksDB) Flush() error {
@@ -107,11 +114,11 @@ func (db *QRocksDB) DeleteExpiredRecords() (deletedCount int, deletionErr error)
 	for it.SeekToFirst(); it.Valid(); it.Next() {
 		retentionKey := NewRetentionPeriodKey(it.Key())
 		if retentionKey.ExpirationDate() <= now {
-			if err := db.db.DeleteCF(db.wo, db.ColumnFamilyHandles()[RecordCF], retentionKey.RecordKey().Data()); err != nil {
+			if err := db.db.DeleteCF(db.dwo, db.ColumnFamilyHandles()[RecordCF], retentionKey.RecordKey().Data()); err != nil {
 				deletionErr = err
 				continue
 			}
-			if err := db.db.DeleteCF(db.wo, db.ColumnFamilyHandles()[RecordExpCF], retentionKey.Data()); err != nil {
+			if err := db.db.DeleteCF(db.dwo, db.ColumnFamilyHandles()[RecordExpCF], retentionKey.Data()); err != nil {
 				deletionErr = err
 				continue
 			}
@@ -120,6 +127,14 @@ func (db *QRocksDB) DeleteExpiredRecords() (deletedCount int, deletionErr error)
 		retentionKey.Free()
 		runtime.Gosched()
 	}
+
+	if err := db.db.FlushCF(db.ColumnFamilyHandles()[RecordCF], db.fo); err != nil {
+		deletionErr = err
+	}
+	if err := db.db.FlushCF(db.ColumnFamilyHandles()[RecordExpCF], db.fo); err != nil {
+		deletionErr = err
+	}
+
 	return
 }
 


### PR DESCRIPTION
### Hotfixes
- Replace DeleteRange to scan-delete
  - Because DeleteRange code was deleting end key only. I think it's a bug of grocksdb or rocksdb. It should be tested too.
- Add `db.Flush()` after deleting rocksdb keys
  - Without `Flush()`, the CPU usage is gradually increasing. And add flushing option and writing option for optimization.
- Move execution code for `retentionScheduler`
  - There was a potential problem on running a retentionScheduler when the accelerator start publishing for multiple topics.
